### PR TITLE
"Corrections to the seeding covariance matrix"

### DIFF
--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -1260,6 +1260,14 @@ int fastParticle::reconstructParticle(fastGeometry  &geom, long pdgCode, uint la
     ((double*)param.GetParameter())[4]*=-1;
     ((double*)param.GetParameter())[3]*=-1;
     ((double*)param.GetParameter())[2]*=-1;
+    
+    ////Rotate Covariance accordingly RCR^T
+    ((double*)param.GetCovariance())[3]*=-1;
+    ((double*)param.GetCovariance())[4]*=-1;
+    ((double*)param.GetCovariance())[6]*=-1;
+    ((double*)param.GetCovariance())[7]*=-1;
+    ((double*)param.GetCovariance())[10]*=-1;
+    ((double*)param.GetCovariance())[11]*=-1;
   }
   //param.fMass=.fMass;
 

--- a/fastMCKalman/MC/fastTracker.h
+++ b/fastMCKalman/MC/fastTracker.h
@@ -118,6 +118,7 @@ AliExternalTrackParam * fastTracker::makeSeed(double xyz0[3], double xyz1[3], do
 
   if (TMath::Abs(bz)>kAlmost0Field) {
     c[14]/=(bz*kB2C)*(bz*kB2C);
+    c[13]/=(bz*kB2C);
     c[12]/=(bz*kB2C);
     c[10]/=(bz*kB2C);
     param[4]/=(bz*kB2C); // transform to 1/pt


### PR DESCRIPTION
Corrected errors in missing rotation of the Covariance matrix after the seeding plus missing conversion from curvature to 1/pT for element c[13]