### PR TITLE
Solved bug which produced extra point with same fX (local) after mirror in simulation. Before and after Mirror should still have the local fX i.e. same radius

### DIFF
--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -1090,9 +1090,8 @@ int fastParticle::simulateParticle(fastGeometry  &geom, double r[3], double p[3]
 
 
       direction*=-1;
-      fDirection[nPoint]=direction;
+      indexR+=direction; ///// needed to unset the previous radius update
       loopCounter++;
-      fLoop[nPoint]=loopCounter;
     }else{
       double alpha  = TMath::ATan2(xyz[1],xyz[0]);
       fStatusMaskMC[nPoint]=0;

--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -1060,6 +1060,7 @@ int fastParticle::simulateParticle(fastGeometry  &geom, double r[3], double p[3]
     int status =  param.GetXYZatR(radius,geom.fBz,xyz);
     if (status==0){   // if not possible to propagate to next radius - assume looper - change direction
 
+      if(nPoint==1) break; // Can't turn immediately otherwise produce infinite looper
       param.GetPxPyPz(pxyz);
       float C         = param.GetC(geom.fBz);
       float R         = TMath::Abs(1/C);
@@ -1476,7 +1477,7 @@ int fastParticle::reconstructParticle(fastGeometry  &geom, long pdgCode, uint in
 /// \return   -  TODO  status flags to be decides
 int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uint indexStart){
   const Float_t chi2Cut=100/(geom.fLayerResolZ[0]);
-  const float kMaxSnp=0.95;
+  const float kMaxSnp=0.98;
   const float kMaxLoss=0.3;
   fLengthIn=0;
   float_t mass=0;
@@ -1495,14 +1496,6 @@ int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uin
   }
   uint index1 = TMath::Min(indexStart,uint(fParamMC.size()-1));
   fMaxLayerRec=index1;
-  /*
-  for (;index1>0; index1--){
-    if (fLoop[index1]>0) continue;                                   // loop number - only closet part of helix to the production vertex
-    if (TMath::Abs(fParamMC[index1].GetSnp())>kMaxSnp) continue;     // track inclination anlge has to be smaller than kmaxSnp
-    fMaxLayerRec=index1;
-    if ((fParamMC[index1].P())>kMaxLoss*fParamMC[0].P()) break;      // if particle momneta is bigger than kMaxLoss production momenta - define starting index
-  }
-  */
 
   if (index1<=3){
     //::Error("fastParticle::reconstructParticle","short track");
@@ -1514,13 +1507,15 @@ int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uin
   Float_t alpha0;
   float sign0;
   float semiplane = -1;
+  float sphi1 = 0.1;
   Int_t step=index1/3;
-  if (step>50) step=50;
+  if (step>10) step=10;
 
-  while(semiplane<0)
+  while(semiplane<0 || sphi1>kMaxSnp)
   {
     sign0=(fParamMC[index1-1].GetX()>fParamMC[index1-2].GetX())? 1.:-1.;
     alpha0=fParamMC[index1-1].GetAlpha();
+
     for (int dLayer=0; dLayer<3  && index1-step*dLayer>0; dLayer++) {
           Int_t index=index1-step*dLayer-1;
           Int_t index0=index1-1;
@@ -1530,16 +1525,34 @@ int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uin
           xyzS[dLayer][2]=fParamMC[index].GetZ();
           fParamMC[index].Local2GlobalPosition(xyzS[dLayer],fParamMC[index].GetAlpha()-alpha0);
     }
-    float sp0 = fastTracker::makeYC(xyzS[0][0],xyzS[0][0],xyzS[1][0],xyzS[1][1],xyzS[2][0],xyzS[2][1]);
-    float sp2 = fastTracker::makeYC(xyzS[2][0],xyzS[2][0],xyzS[1][0],xyzS[1][1],xyzS[0][0],xyzS[0][1]);
+
+    sphi1 = TMath::Abs(fastTracker::makeSnp(xyzS[0][0],xyzS[0][1],xyzS[1][0],xyzS[1][1],xyzS[2][0],xyzS[2][1]));
+    if(sphi1>kMaxSnp) {
+      index1-=1;
+      if((index1)<=3) break;
+      step=index1/3;
+      if (step>10) step=10;
+      continue;
+    }
+    
+    float sp0 = fastTracker::makeYC(xyzS[0][0],xyzS[0][1],xyzS[1][0],xyzS[1][1],xyzS[2][0],xyzS[2][1]);
+    float sp2 = fastTracker::makeYC(xyzS[2][0],xyzS[2][1],xyzS[1][0],xyzS[1][1],xyzS[0][0],xyzS[0][1]);  
     semiplane = sp0*sp2; ///if <0 the two points are in different semiplanes
+
     if(semiplane<0) step-=1;
-    if(step==0) break;
+    if(step==0) 
+    {
+      index1-=1;
+      if((index1)<=3) break;
+      step=index1/3;
+      if (step>10) step=10;
+      continue;
+    }
   }
 
-  if (step==0)
+  if (step==0 || (index1)<=3)
   {
-    ::Error("fastParticle::reconstructParticle", "Too few points in same semiplane");
+    ::Error("fastParticle::reconstructParticle", "Too few consecutive points in same semiplane");
     return -1;
   }
 

--- a/fastMCKalman/MC/fastSimulationTest.C
+++ b/fastMCKalman/MC/fastSimulationTest.C
@@ -107,8 +107,10 @@ void testTPC(Int_t nParticles, bool dumpStream=1){
     Float_t decayLength= hasDecay ?gRandom->Rndm()*geom.fLayerRadius[geom.fLayerRadius.size()-1]:0;
     particle.fDecayLength=decayLength;
     particle.simulateParticle(geom, r,p,pdgCode,nPoints,nPoints);
+    particle.reconstructParticle(geom,pdgCode,nPoints);
+    fastParticle particle0 = particle;
     particle.reconstructParticleFull(geom,pdgCode,nPoints);
-    particle.reconstructParticleRotate0(geom,pdgCode,nPoints);
+    //particle.reconstructParticleRotate0(geom,pdgCode,nPoints);
     //particle.simulateParticle(geom, r,p,211, 250,161);
     //particle.reconstructParticle(geom,211,160);
     if (dumpStream==kFALSE) continue;
@@ -122,7 +124,8 @@ void testTPC(Int_t nParticles, bool dumpStream=1){
                   "pidCode="<<pidCode<<
                   "pdgCode="<<pdgCode<<
                   "charge="<<charge<<
-                  "part.=" << &particle <<
+                  "part.=" << &particle0 <<
+                  "partFull.=" << &particle <<
                   "\n";
       tree=  ((*pcstream) << "fastPart").GetTree();
     }

--- a/fastMCKalman/MC/fastTracker.h
+++ b/fastMCKalman/MC/fastTracker.h
@@ -15,6 +15,7 @@ public:
   static AliExternalTrackParam* makeSeedMB(double xyz0[3], double xyz1[3], double xyz2[3], double sy, double sz, float bz, float xx0, float xrho, float mass,int nSteps=5);
   static Double_t makeC(Double_t x1,Double_t y1, Double_t x2,Double_t y2, Double_t x3,Double_t y3);     // F1
   static Double_t makeSnp(Double_t x1,Double_t y1,Double_t x2,Double_t y2,Double_t x3,Double_t y3);     // F2
+  static Double_t makeYC(Double_t x1,Double_t y1,Double_t x2,Double_t y2,Double_t x3,Double_t y3);     // YC
   static Double_t makeTgln(Double_t x1,Double_t y1, Double_t x2,Double_t y2, Double_t z1,Double_t z2,Double_t c);   // F3n
 };
 
@@ -64,6 +65,25 @@ Double_t fastTracker::makeSnp(Double_t x1,Double_t y1, Double_t x2,Double_t y2, 
   if (det>0) c2*=-1;
   x0*=c2;  
   return x0;
+}
+
+Double_t fastTracker::makeYC(Double_t x1,Double_t y1, Double_t x2,Double_t y2, Double_t x3,Double_t y3){
+  //-----------------------------------------------------------------
+  // Initial approximation of the track snp at position x1
+  //-----------------------------------------------------------------
+  x3 -=x1;
+  x2 -=x1;
+  y3 -=y1;
+  y2 -=y1;
+  //  
+  Double_t det = x3*y2-x2*y3;
+  if (TMath::Abs(det)<1e-10) {
+    return 100;
+  }
+  //
+  Double_t u = 0.5* (x2*(x2-x3)+y2*(y2-y3))/det;
+  Double_t y0 = y3*0.5+x3*u;
+  return y0;
 }
 
 //_____________________________________________________________________________

--- a/fastMCKalman/MC/fastTracker.h
+++ b/fastMCKalman/MC/fastTracker.h
@@ -69,7 +69,10 @@ Double_t fastTracker::makeSnp(Double_t x1,Double_t y1, Double_t x2,Double_t y2, 
 
 Double_t fastTracker::makeYC(Double_t x1,Double_t y1, Double_t x2,Double_t y2, Double_t x3,Double_t y3){
   //-----------------------------------------------------------------
-  // Initial approximation of the track snp at position x1
+  // Initial approximation of the y coordinate of the center of the track circumference 
+  // in the xy plane, with respects to the first point (x1,y1). Used to check consistency 
+  // between points (i.e. if they are in the the same semiplane), not in the seeding itself. 
+  // If the sign of yC is the same, the points are in the same semiplane.
   //-----------------------------------------------------------------
   x3 -=x1;
   x2 -=x1;


### PR DESCRIPTION
Tested with treeFast->Draw("gyMC:gxMC:(part.fParamMC[].fX==part.fParamMC[Iteration$-2].fX)","Iteration$>2","colz",10);