### PR TITLE
Modified UnitTest.sh to include Rotation errors; Corrected spelling mistake and removed snp protection in ReconstructParticle  in fastSimulation.cxx; Modified Update function to accomodate for snp close to 1

### DIFF
--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -1454,7 +1454,7 @@ int fastParticle::reconstructParticle(fastGeometry  &geom, long pdgCode, uint in
       if (status) {
         fStatusMaskIn[index]|=kTrackPropagate;
       }else{
-        ::Error("fastParticle::reconstructParticle:", "Proapagation failed");
+        ::Error("fastParticle::reconstructParticle:", "Propagation failed");
         break;
       }
       float xrho  =geom.fLayerRho[layer];
@@ -1476,7 +1476,7 @@ int fastParticle::reconstructParticle(fastGeometry  &geom, long pdgCode, uint in
         ::Error("fastParticle::reconstructParticle:", "Too big chi2 %f", chi2);
         break;
       }
-      if (TMath::Abs(param.GetSnp())<kMaxSnp && cov[0]>0) {
+      if (cov[0]>0) {
         status = param.Update(pos, cov);
         if (status) {
           fStatusMaskIn[index]|=kTrackUpdate;
@@ -1484,6 +1484,10 @@ int fastParticle::reconstructParticle(fastGeometry  &geom, long pdgCode, uint in
           ::Error("fastParticle::reconstructParticle:", "Update failed");
           break;
         }
+      }
+      else{
+          ::Error("fastParticle::reconstructParticle:", "Update failed");
+          break;
       }
 
       float tanPhi2 = par[2]*par[2];

--- a/fastMCKalman/aliKalman/test/AliExternalTrackParam.cpp
+++ b/fastMCKalman/aliKalman/test/AliExternalTrackParam.cpp
@@ -1495,7 +1495,10 @@ Bool_t AliExternalTrackParam::Update(const Double_t p[2], const Double_t cov[3])
 
   Double_t dy=p[0] - fP0, dz=p[1] - fP1;
   Double_t sf=fP2 + k20*dy + k21*dz;
-  if (TMath::Abs(sf) > kAlmost1) return kFALSE;  
+  if (TMath::Abs(sf) > kAlmost1) 
+  {
+    sf = (sf>0?1:-1) * (1-sqrt(fC[5]));
+  }  
   
   fP0 += k00*dy + k01*dz;
   fP1 += k10*dy + k11*dz;

--- a/fastMCKalman/tests/unitTest.sh
+++ b/fastMCKalman/tests/unitTest.sh
@@ -47,11 +47,12 @@ EOF
 }
 
 analyzeLogs(){
-   errors=( "short track" "Too few consecutive points" "Incorrect rotation of first point" "Propagation failed" "Update failed" "Too big chi2"
+   errors=( "short track" "Too few consecutive points" "Rotation failed" "Propagation failed" "Update failed" "Too big chi2"
    "Correct for material failed" )
    errorSources=( "fastParticle::reconstructParticleFull:" "fastParticle::reconstructParticle:" )
    for errorSource in  "${errorSources[@]}"; do
-      echo  ${errorSource}
+      nErrorstot=$(cat makeData.log | grep -c ${errorSource})
+      echo  ${errorSource} ${nErrorstot}
       for error in "${errors[@]}"; do
         nErrors=$(cat makeData.log | grep ${errorSource} | grep -c "${error}")
         echo ${errorSource} ${error} ${nErrors}

--- a/fastMCKalman/tests/unitTest.sh
+++ b/fastMCKalman/tests/unitTest.sh
@@ -21,6 +21,7 @@ makeData(){
    .L $fastMCKalman/fastMCKalman/MC/fastSimulation.cxx+g
     .L $fastMCKalman/fastMCKalman/MC/fastSimulationTest.C+g
     AliPDG::AddParticlesToPdgDataBase();
+    AliLog::SetPrintRepetitions(0);
     testTPC(10000,kTRUE);            //setup for the looper development
     .q
 EOF


### PR DESCRIPTION
Before change to Update we got these errors:

fastParticle::reconstructParticleFull: 3343
fastParticle::reconstructParticleFull: short track 2321
fastParticle::reconstructParticleFull: Too few consecutive points 65
fastParticle::reconstructParticleFull: Rotation failed 112
fastParticle::reconstructParticleFull: Propagation failed 256
fastParticle::reconstructParticleFull: Update failed 434
fastParticle::reconstructParticleFull: Too big chi2 155
fastParticle::reconstructParticleFull: Correct for material failed 0
fastParticle::reconstructParticle: 2743
fastParticle::reconstructParticle: short track 2692
fastParticle::reconstructParticle: Too few consecutive points 0
fastParticle::reconstructParticle: Rotation failed 0
fastParticle::reconstructParticle: Propagation failed 20
fastParticle::reconstructParticle: Update failed 28
fastParticle::reconstructParticle: Too big chi2 3
fastParticle::reconstructParticle: Correct for material failed 0

After the modification to Update errors are totally removed and only some are traslated to other errors (total reduction of about 200 errors):

fastParticle::reconstructParticleFull: 3107
fastParticle::reconstructParticleFull: short track 2364
fastParticle::reconstructParticleFull: Too few consecutive points 73
fastParticle::reconstructParticleFull: Rotation failed 186
fastParticle::reconstructParticleFull: Propagation failed 333
fastParticle::reconstructParticleFull: Update failed 0
fastParticle::reconstructParticleFull: Too big chi2 151
fastParticle::reconstructParticleFull: Correct for material failed 0
fastParticle::reconstructParticle: 2756
fastParticle::reconstructParticle: short track 2731
fastParticle::reconstructParticle: Too few consecutive points 0
fastParticle::reconstructParticle: Rotation failed 2
fastParticle::reconstructParticle: Propagation failed 13
fastParticle::reconstructParticle: Update failed 0
fastParticle::reconstructParticle: Too big chi2 10
fastParticle::reconstructParticle: Correct for material failed 0