### PR TITLE
Made override versions of Update and PropagateTo with modifications for |snp|~1 and reverted modifications to Update in Alice code. Added protection for Rotation in ReconstructFull. Restricted chi2Cut to points far from the snp edges.

### DIFF
--- a/fastMCKalman/MC/fastSimulation.h
+++ b/fastMCKalman/MC/fastSimulation.h
@@ -32,7 +32,9 @@ public:
   Double_t GetOverThr(Float_t sigma=0.01, Float_t width=0.0005, Float_t threshold=0.1);
   Int_t GetDirectionSign();
   //
+  Bool_t PropagateTo(Double_t xk, Double_t b);
   Bool_t PropagateTo(Double_t xk, Double_t b, Int_t timeDir);
+  Bool_t Update(const Double_t p[2], const Double_t cov[3]);
   Double_t PropagateToMirrorX(Double_t b, Float_t dir, Double_t  sy, Double_t sz);
   Bool_t GetXYZatR(Double_t xr,Double_t bz, Double_t *xyz=0, Double_t* alpSect=0) const;
   //

--- a/fastMCKalman/aliKalman/test/AliExternalTrackParam.cpp
+++ b/fastMCKalman/aliKalman/test/AliExternalTrackParam.cpp
@@ -1495,10 +1495,7 @@ Bool_t AliExternalTrackParam::Update(const Double_t p[2], const Double_t cov[3])
 
   Double_t dy=p[0] - fP0, dz=p[1] - fP1;
   Double_t sf=fP2 + k20*dy + k21*dz;
-  if (TMath::Abs(sf) > kAlmost1) 
-  {
-    sf = (sf>0?1:-1) * (1-sqrt(fC[5]));
-  }  
+  if (TMath::Abs(sf) > kAlmost1) return kFALSE;
   
   fP0 += k00*dy + k01*dz;
   fP1 += k10*dy + k11*dz;


### PR DESCRIPTION
New results of reconstruction:

fastParticle::reconstructParticleFull: 2484
fastParticle::reconstructParticleFull: short track 2287
fastParticle::reconstructParticleFull: Too few consecutive points 62
fastParticle::reconstructParticleFull: Rotation failed 4
fastParticle::reconstructParticleFull: Propagation failed 0
fastParticle::reconstructParticleFull: Update failed 0
fastParticle::reconstructParticleFull: Too big chi2 86
fastParticle::reconstructParticleFull: Correct for material failed 7
fastParticle::reconstructParticleFull: PropagateToMirrorX failed 38
fastParticle::reconstructParticle: 2630
fastParticle::reconstructParticle: short track 2623
fastParticle::reconstructParticle: Too few consecutive points 0
fastParticle::reconstructParticle: Rotation failed 1
fastParticle::reconstructParticle: Propagation failed 0
fastParticle::reconstructParticle: Update failed 0
fastParticle::reconstructParticle: Too big chi2 6
fastParticle::reconstructParticle: Correct for material failed 0
fastParticle::reconstructParticle: PropagateToMirrorX failed 0