### PR TITLE
Corrected calculation of sigmadE (sqrt not needed)

### DIFF
--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -511,7 +511,7 @@ Bool_t AliExternalTrackParam4D::CorrectForMeanMaterial(Double_t xOverX0, Double_
     //if (TMath::Abs(fP4*cP4)>100.) return kFALSE; //Do not track below 10 MeV/c -dsiable controlled by the BG cut
     // Approximate energy loss fluctuation (M.Ivanov)
     const Double_t knst=0.07; // To be tuned.
-    Double_t sigmadE=knst*TMath::Sqrt(TMath::Abs(dE));
+    Double_t sigmadE=knst*TMath::Abs(dE);
     cC44 += ((sigmadE*Ein/p2*fP4)*(sigmadE*Ein/p2*fP4));
     //
     sigmadPRel=TMath::Abs(pOut-pOld)*knst/pOld;


### PR DESCRIPTION
Corrected mistake in sigmadE: sqrt not needed

New Pulls for the kalman filter reconstruction are a lot closer to 1:
Info in <testFastTracker part reco pull test P0 >: pullAnalytical - OK - 0.960927
Info in <testFastTracker part reco pull test P1 >: pullAnalytical - OK - 1.005405
Info in <testFastTracker part reco pull test P2 >: pullAnalytical - OK - 1.035221
Info in <testFastTracker part reco pull test P3 >: pullAnalytical - OK - 1.007811
Error in <testFastTracker part reco pull test P4>: pullAnalytical- FAILED- 0.909541
Info in <testFastTracker partFull reco pull test P0 >: pullAnalytical - OK - 0.983737
Info in <testFastTracker partFull reco pull test P1 >: pullAnalytical - OK - 1.016043
Error in <testFastTracker partFull reco pull test P2>: pullAnalytical- FAILED- 1.060995
Info in <testFastTracker partFull reco pull test P3 >: pullAnalytical - OK - 1.005980
Error in <testFastTracker partFull reco pull test P4>: pullAnalytical- FAILED- 0.933101