### PR TITLE
FixUpdate

### DIFF
--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -1023,6 +1023,7 @@ int fastParticle::simulateParticle(fastGeometry  &geom, double r[3], double p[3]
   fMaxLayer=0;
   const float kMaxSnp=0.90;
   const float kMaxLoss=0.5;
+  const float kMaxZ=300;
    double covar[21]={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
    float_t mass=0,sign=1;
   fPdgCodeMC=pdgCode;
@@ -1082,7 +1083,7 @@ int fastParticle::simulateParticle(fastGeometry  &geom, double r[3], double p[3]
     float crossLength = 0;
     //printf("%d\n",nPoint);
     //param.Print();
-    if (indexR>=geom.fLayerRadius.size()) {
+    if (indexR>=geom.fLayerRadius.size() || TMath::Abs(param.GetZ())>kMaxZ) {
       break;
     }
     if (fStatusMaskMC.size()<=nPoint) fStatusMaskMC.resize(nPoint+1);

--- a/fastMCKalman/aliKalman/test/AliExternalTrackParam.cpp
+++ b/fastMCKalman/aliKalman/test/AliExternalTrackParam.cpp
@@ -1495,10 +1495,7 @@ Bool_t AliExternalTrackParam::Update(const Double_t p[2], const Double_t cov[3])
 
   Double_t dy=p[0] - fP0, dz=p[1] - fP1;
   Double_t sf=fP2 + k20*dy + k21*dz;
-  if (TMath::Abs(sf) > kAlmost1) 
-  {
-    sf = (sf>0?1:-1) * (1-sqrt(fC[5]));
-  }  
+  if (TMath::Abs(sf) > kAlmost1) return kFALSE;
   
   fP0 += k00*dy + k01*dz;
   fP1 += k10*dy + k11*dz;


### PR DESCRIPTION
Reverted to older version of update; Added skip if update fails and added protection on z to avoid it being too large.

Old pull tests vs new:
fastParticle::reconstructParticleFull: 3304
fastParticle::reconstructParticleFull: short track 2329
fastParticle::reconstructParticleFull: Too few consecutive points 51
fastParticle::reconstructParticleFull: Rotation failed 160
fastParticle::reconstructParticleFull: Propagation failed 188
fastParticle::reconstructParticleFull: Update failed 434
fastParticle::reconstructParticleFull: Too big chi2 113
fastParticle::reconstructParticleFull: Correct for material failed 8
fastParticle::reconstructParticleFull: PropagateToMirrorX failed 21
fastParticle::reconstructParticle: 2696
fastParticle::reconstructParticle: short track 2629
fastParticle::reconstructParticle: Too few consecutive points 0
fastParticle::reconstructParticle: Rotation failed 3
fastParticle::reconstructParticle: Propagation failed 21
fastParticle::reconstructParticle: Update failed 26
fastParticle::reconstructParticle: Too big chi2 2
fastParticle::reconstructParticle: Correct for material failed 15
fastParticle::reconstructParticle: PropagateToMirrorX failed 0

fastParticle::reconstructParticleFull: 3026
fastParticle::reconstructParticleFull: short track 2357
fastParticle::reconstructParticleFull: Too few consecutive points 59
fastParticle::reconstructParticleFull: Rotation failed 185
fastParticle::reconstructParticleFull: Propagation failed 259
fastParticle::reconstructParticleFull: Update failed 0
fastParticle::reconstructParticleFull: Too big chi2 124
fastParticle::reconstructParticleFull: Correct for material failed 15
fastParticle::reconstructParticleFull: PropagateToMirrorX failed 27
fastParticle::reconstructParticle: 2781
fastParticle::reconstructParticle: short track 2711
fastParticle::reconstructParticle: Too few consecutive points 0
fastParticle::reconstructParticle: Rotation failed 1
fastParticle::reconstructParticle: Propagation failed 17
fastParticle::reconstructParticle: Update failed 26
fastParticle::reconstructParticle: Too big chi2 10
fastParticle::reconstructParticle: Correct for material failed 16
fastParticle::reconstructParticle: PropagateToMirrorX failed 0