### PR TITLE
Added refit function and relative parameters

### DIFF
--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -1120,16 +1120,19 @@ void fastParticle::refitParticle()
     {
       fParamRefit[i]=fParamIn[i];
       fStatusMaskRefit[i]|=kTrackUsedIn;
+      fStatusMaskRefit[i]|=kTrackisOK;
     }
     else if(!statusIn && statusOut)
     {
       fParamRefit[i]=fParamOut[i];
       fStatusMaskRefit[i]|=kTrackUsedOut;
+      fStatusMaskRefit[i]|=kTrackisOK;
     }
     else if (statusIn && statusOut)
     {
       AliExternalTrackParam4D::UpdateTrack(fParamRefit[i],fParamOut[i]);
       fStatusMaskRefit[i]|=kTrackRefitted;
+      fStatusMaskRefit[i]|=kTrackisOK;
     }
     int checkpoint=0;
 
@@ -1647,6 +1650,7 @@ int fastParticle::reconstructParticle(fastGeometry  &geom, long pdgCode, uint in
         break;
       }
       fLengthIn++;
+      fStatusMaskIn[index]|=kTrackisOK;
   }
   return 1;
 }
@@ -1866,6 +1870,7 @@ int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uin
           index=new_index;
           fParamIn[index]=param;
           fStatusMaskIn[index]|=kTrackPropagatetoMirrorX;
+          fStatusMaskIn[index]|=kTrackisOK;
           checkloop=0;
           continue;
       }
@@ -1993,6 +1998,7 @@ int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uin
         }
       }
       fLengthIn++;
+      fStatusMaskIn[index]|=kTrackisOK;
   }
   return 1;
   
@@ -2211,6 +2217,7 @@ int fastParticle::reconstructParticleFullOut(fastGeometry  &geom, long pdgCode, 
           index=new_index;
           fParamOut[index]=param;
           fStatusMaskOut[index]|=kTrackPropagatetoMirrorX;
+          fStatusMaskOut[index]|=kTrackisOK;
           checkloop=0;
           continue;
       }
@@ -2337,6 +2344,7 @@ int fastParticle::reconstructParticleFullOut(fastGeometry  &geom, long pdgCode, 
         }
       }
       fLengthOut++;
+      fStatusMaskOut[index]|=kTrackisOK;
   }
   return 1;
   

--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -11,6 +11,7 @@
 #include "TTreeStream.h"
 #include "TRandom.h"
 #include "fastTracker.h"
+#include <TMatrixD.h>
 
 
 TTreeSRedirector* fastParticle::fgStreamer = nullptr;
@@ -957,6 +958,82 @@ void AliExternalTrackParam4D::UnitTestDumpCorrectForMaterial(TTreeSRedirector * 
               "\n";
 }
 
+void AliExternalTrackParam4D::UpdateTrack(AliExternalTrackParam4D &track1, const AliExternalTrackParam4D &track2){
+  //
+  // Update track 1 with track 2
+  //
+  //
+  //
+  TMatrixD vecXk(5,1);    // X vector
+  TMatrixD covXk(5,5);    // X covariance 
+  TMatrixD matHk(5,5);    // vector to mesurement
+  TMatrixD measR(5,5);    // measurement error 
+  TMatrixD vecZk(5,1);    // measurement
+  //
+  TMatrixD vecYk(5,1);    // Innovation or measurement residual
+  TMatrixD matHkT(5,5);
+  TMatrixD matSk(5,5);    // Innovation (or residual) covariance
+  TMatrixD matKk(5,5);    // Optimal Kalman gain
+  TMatrixD mat1(5,5);     // update covariance matrix
+  TMatrixD covXk2(5,5);   // 
+  TMatrixD covOut(5,5);
+  //
+  Double_t *param1=(Double_t*) track1.GetParameter();
+  Double_t *covar1=(Double_t*) track1.GetCovariance();
+  Double_t *param2=(Double_t*) track2.GetParameter();
+  Double_t *covar2=(Double_t*) track2.GetCovariance();
+  //
+  // copy data to the matrix
+  for (Int_t ipar=0; ipar<5; ipar++){
+    for (Int_t jpar=0; jpar<5; jpar++){
+      covXk(ipar,jpar) = covar1[track1.GetIndex(ipar, jpar)];
+      measR(ipar,jpar) = covar2[track2.GetIndex(ipar, jpar)];
+      matHk(ipar,jpar)=0;
+      mat1(ipar,jpar)=0;
+    }
+    vecXk(ipar,0) = param1[ipar];
+    vecZk(ipar,0) = param2[ipar];
+    matHk(ipar,ipar)=1;
+    mat1(ipar,ipar)=1;
+  }
+  //
+  //
+  //
+  //
+  //
+  vecYk = vecZk-matHk*vecXk;                 // Innovation or measurement residual
+  matHkT=matHk.T(); matHk.T();
+  matSk = (matHk*(covXk*matHkT))+measR;      // Innovation (or residual) covariance
+  matSk.Invert();
+  matKk = (covXk*matHkT)*matSk;              //  Optimal Kalman gain
+  vecXk += matKk*vecYk;                      //  updated vector 
+  covXk2 = (mat1-(matKk*matHk));
+  covOut =  covXk2*covXk; 
+  //
+  //
+  //
+  // copy from matrix to parameters
+  if (0) {
+    vecXk.Print();
+    vecZk.Print();
+    //
+    measR.Print();
+    covXk.Print();
+    covOut.Print();
+    //
+    track1.Print();
+    track2.Print();
+  }
+
+
+  for (Int_t ipar=0; ipar<5; ipar++){
+    param1[ipar]= vecXk(ipar,0) ;
+    for (Int_t jpar=0; jpar<5; jpar++){
+      covar1[track1.GetIndex(ipar, jpar)]=covOut(ipar,jpar);
+    }
+  }
+}
+
 void getHelix(Double_t *fHelix,  AliExternalTrackParam t, float bz){
   // addapted code from AliHelix
   Double_t x,cs,sn;
@@ -1009,6 +1086,54 @@ void fastGeometry::setLayer(int iLayer, float radius,  float X0,float rho, float
   fLayerRadius[iLayer] = radius;
   fLayerResolRPhi[iLayer] = resol[0];
   fLayerResolZ[iLayer] = resol[1];
+}
+
+
+void fastParticle::refitParticle()
+{
+  fParamRefit = fParamIn;
+  fParamRefit.resize(fParamIn.size());
+  fStatusMaskRefit.resize(fParamIn.size());
+  for(size_t i=0; i<fParamRefit.size();i++) fStatusMaskRefit[i]=0;
+  for(size_t i=0; i<fParamRefit.size();i++)
+  {
+    Bool_t statusIn= kFALSE;
+    Bool_t statusOut = kFALSE;
+
+    std::uint16_t flagsIn=fStatusMaskIn[i];
+
+    if(((flagsIn & kTrackEnter) && (flagsIn & kTrackRotate) && (flagsIn & kTrackPropagate) && (flagsIn & kTrackChi2) && (flagsIn & kTrackUpdate) && (flagsIn & kTrackCorrectForMaterial))
+       ||((flagsIn & kTrackEnter) && (flagsIn & kTrackRotate) && (flagsIn & kTrackPropagate) && (flagsIn & kTrackChi2) && (flagsIn & kTrackSkipUpdate ) ))
+    {
+      statusIn=kTRUE;
+    }
+
+    std::uint16_t flagsOut=fStatusMaskOut[i]; 
+
+    if(((flagsOut & kTrackEnter) && (flagsOut & kTrackRotate) && (flagsOut & kTrackPropagate) && (flagsOut & kTrackChi2) && (flagsOut & kTrackUpdate) && (flagsOut & kTrackCorrectForMaterial))
+       ||((flagsOut & kTrackEnter) && (flagsOut & kTrackRotate) && (flagsOut & kTrackPropagate) && (flagsOut & kTrackChi2) && (flagsOut & kTrackSkipUpdate ) ))
+    {
+      statusOut=kTRUE;
+    }
+
+    if(statusIn && !statusOut)
+    {
+      fParamRefit[i]=fParamIn[i];
+      fStatusMaskRefit[i]|=kTrackUsedIn;
+    }
+    else if(!statusIn && statusOut)
+    {
+      fParamRefit[i]=fParamOut[i];
+      fStatusMaskRefit[i]|=kTrackUsedOut;
+    }
+    else if (statusIn && statusOut)
+    {
+      AliExternalTrackParam4D::UpdateTrack(fParamRefit[i],fParamOut[i]);
+      fStatusMaskRefit[i]|=kTrackRefitted;
+    }
+    int checkpoint=0;
+
+  }
 }
 
 /// simulate particle    - barrel part, end cup and loopers not yet implemented
@@ -1840,7 +1965,7 @@ int fastParticle::reconstructParticleFull(fastGeometry  &geom, long pdgCode, uin
           fStatusMaskIn[index]|=kTrackUpdate;
         }else{
             ///skip the Update
-            fStatusMaskIn[index]|=kTrackSkip;
+            fStatusMaskIn[index]|=kTrackSkipUpdate;
             SkipUpdate = kTRUE;
         }
       }
@@ -2184,7 +2309,7 @@ int fastParticle::reconstructParticleFullOut(fastGeometry  &geom, long pdgCode, 
           fStatusMaskOut[index]|=kTrackUpdate;
         }else{
             ///skip the Update
-            fStatusMaskOut[index]|=kTrackSkip;
+            fStatusMaskOut[index]|=kTrackSkipUpdate;
             SkipUpdate = kTRUE;
         }
       }

--- a/fastMCKalman/MC/fastSimulation.cxx
+++ b/fastMCKalman/MC/fastSimulation.cxx
@@ -2332,10 +2332,10 @@ int fastParticle::reconstructParticleFullOut(fastGeometry  &geom, long pdgCode, 
       if(!SkipUpdate)
       {
         for (Int_t ic=0;ic<5; ic++) {
-          status*= param.CorrectForMeanMaterial(crossLength * xx0/5., crossLength * xrho/5., mass, 0.01);
+          status*= param.CorrectForMeanMaterial(crossLength * xx0/5., -crossLength * xrho/5., mass, 0.01);
         }
         //status = param.CorrectForMeanMaterialT4(crossLength*xx0,crossLength*xrho,mass);
-        if (gRandom->Rndm() <fracUnitTest) param.UnitTestDumpCorrectForMaterial(fgStreamer,crossLength*xx0,crossLength*xrho,mass,20);
+        if (gRandom->Rndm() <fracUnitTest) param.UnitTestDumpCorrectForMaterial(fgStreamer,crossLength*xx0,-crossLength*xrho,mass,20);
         if (status) {
           fStatusMaskOut[index]|=kTrackCorrectForMaterial;
         }else{

--- a/fastMCKalman/MC/fastSimulation.h
+++ b/fastMCKalman/MC/fastSimulation.h
@@ -98,7 +98,8 @@ public:
   kTrackSkipUpdate =0x200,
   kTrackUsedIn =0x400,
   kTrackUsedOut =0x800,
-  kTrackRefitted =0x1000
+  kTrackRefitted =0x1000,
+  kTrackisOK=0x2000
 } ;
 
   fastParticle():TObject(),fAddMSsmearing(0),fAddPadsmearing(1),fUseMCInfo(1),gid(0){}

--- a/fastMCKalman/MC/fastSimulation.h
+++ b/fastMCKalman/MC/fastSimulation.h
@@ -53,6 +53,7 @@ public:
   //Bool_t GetXYZAt(Double_t x, Double_t b, Double_t *r) const;
   // Uit test functions
   void UnitTestDumpCorrectForMaterial(TTreeSRedirector * pcstream, Double_t xOverX0, Double_t xTimesRho,Double_t mass, Int_t nSteps, Float_t stepFraction=0.02);
+  static void UpdateTrack(AliExternalTrackParam4D &track1, const AliExternalTrackParam4D &track2);
 public:
   Int_t    fZ;         // particle Z
   Double_t fMass;      // particle mass
@@ -93,15 +94,19 @@ public:
   kTrackCorrectForMaterial =0x20,
   kTrackPropagatetoMirrorX =0x40,
   kTrackSkip =0x80,
-  kTrackSkipRotate =0x100
+  kTrackSkipRotate =0x100,
+  kTrackSkipUpdate =0x200,
+  kTrackUsedIn =0x400,
+  kTrackUsedOut =0x800,
+  kTrackRefitted =0x1000
 } ;
 
   fastParticle():TObject(),fAddMSsmearing(0),fAddPadsmearing(1),fUseMCInfo(1),gid(0){}
   ~fastParticle(){}
   fastParticle(int nLayers){
     fLayerIndex.reserve(nLayers); fDirection.reserve(nLayers); fParamIn.reserve(nLayers); fParamInRot.reserve(nLayers);
-    fParamOut.reserve(nLayers); fParamMC.reserve(nLayers);fStatusMaskMC.reserve(nLayers); fStatusMaskIn.reserve(nLayers);
-    fStatusMaskOut.reserve(nLayers); fChi2.resize(nLayers);fLoop.reserve(nLayers);
+    fParamOut.reserve(nLayers); fParamRefit.reserve(nLayers); fParamMC.reserve(nLayers);fStatusMaskMC.reserve(nLayers); fStatusMaskIn.reserve(nLayers);
+    fStatusMaskOut.reserve(nLayers); fStatusMaskRefit.reserve(nLayers); fChi2.resize(nLayers);fLoop.reserve(nLayers);
     fMaxLayer=0;
     fDecayLength=0;
   }
@@ -114,6 +119,7 @@ public:
   int reconstructParticleFull(fastGeometry  &geom, long pdgCode, uint layerStart);
   int reconstructParticleFullOut(fastGeometry  &geom, long pdgCode, uint indexStart);
   int reconstructParticleRotate0(fastGeometry  &geom, long pdgCode, uint layerStart);
+  void refitParticle();
   static void setAliases(TTree & tree);           //   set aliases for derived variables
   int                        fAddMSsmearing;     //   flag to add smearing during simulation
   int                        fAddPadsmearing;     //   flag to add Pad smearing during reconstruction
@@ -139,12 +145,14 @@ public:
   RVec<float>                  fDirection;  //   particle direction - Out=1, In = -1
   RVec<int>                   fLoop;          //   particle loop counter
   RVec<AliExternalTrackParam4D> fParamMC;    //   "simulate"      Param MC
+  RVec<AliExternalTrackParam4D> fParamRefit;   //   "reconstructed" Param Out
   RVec<AliExternalTrackParam4D> fParamOut;   //   "reconstructed" Param Out
   RVec<AliExternalTrackParam4D> fParamIn;    //   "reconstructed" Param In
   RVec<AliExternalTrackParam4D> fParamInRot;    //   "reconstructed" Param In - in rotated frame
   RVec<int>      fStatusMaskMC;     //   rotation(0x1)/propagation(0x2)/correct for material(0x4)/update(0x8)
   RVec<int>      fStatusMaskIn;     //   rotation(0x1)/propagation(0x2)/correct for material(0x4)/update(0x8)
   RVec<int>      fStatusMaskOut;     //   rotation(0x1)/propagation(0x2)/correct for material(0x4)/update(0x8)
+  RVec<int>      fStatusMaskRefit;     //   rotation(0x1)/propagation(0x2)/correct for material(0x4)/update(0x8)
   RVec<int>      fStatusMaskInRot;     //   rotation(0x1)/propagation(0x2)/correct for material(0x4)/update(0x8)
   RVec<float>                 fChi2;      //   chi2  at layer
   //                                       - local information - to be assigned to simulated track - if not set  taken symmetric from fastGeometry

--- a/fastMCKalman/MC/fastSimulationTest.C
+++ b/fastMCKalman/MC/fastSimulationTest.C
@@ -113,6 +113,7 @@ void testTPC(Int_t nParticles, bool dumpStream=1){
     fastParticle particle0 = particle;
     particle.reconstructParticleFull(geom,pdgCode,nPoints);
     particle.reconstructParticleFullOut(geom,pdgCode,nPoints);
+    particle.refitParticle();
     //particle.reconstructParticleRotate0(geom,pdgCode,nPoints);
     //particle.simulateParticle(geom, r,p,211, 250,161);
     //particle.reconstructParticle(geom,211,160);

--- a/fastMCKalman/MC/test_fastSimulation.C
+++ b/fastMCKalman/MC/test_fastSimulation.C
@@ -61,7 +61,7 @@ void testLooperSmooth(){
 
 void testPulls(std::string sv="", std::string Id="In", std::string extra_condition="&&Iteration$==0") {
   TF1 *mygauss = new TF1("mygauss", "gaus");
-  int isOK=fastParticle::kTrackUpdate |fastParticle::kTrackChi2;
+  int isOK=fastParticle::kTrackisOK;
     for (int iPar = 0; iPar <= 4; iPar++) {
       treeFast->Draw(Form("(part%s.fParam%s[].fP[%d]-part%s.fParamMC[].fP[%d])/sqrt(part%s.fParam%s[].fC[%d])>>his(100,-6,6)",sv.c_str(),Id.c_str(), iPar, sv.c_str(), iPar, sv.c_str(),Id.c_str(), AliExternalTrackParam::GetIndex(iPar, iPar)),
                     Form("(part%s.fStatusMask%s[].fData&%d)==%d&&abs(part%s.fParam%s[].fP[2])<0.7%s",sv.c_str(),Id.c_str(),isOK,isOK,sv.c_str(),Id.c_str(),extra_condition.c_str()), "");
@@ -137,7 +137,7 @@ void drawTrackStatus3D(int counter, std::string Id = "In", std::string Error = "
   treeFast->SetMarkerColor(1);   /// all MC
   treeFast->Draw("gyMC:gxMC:gzMC","","",1,counter);
   treeFast->SetMarkerColor(4);   /// all reco points
-  treeFast->Draw("gyInF:gxInF:gzInF",Form("partFull.fStatusMask%s.fData>0",Id.c_str()),"same",1,counter);
+  treeFast->Draw("gyInF:gxInF:gzInF",Form("partFull.fStatusMask.fData%s>0",Id.c_str()),"same",1,counter);
   treeFast->SetMarkerColor(2);   /// first MC point
   treeFast->Draw("gyMC:gxMC:gzMC","Iteration$==0","same",1,counter);
   treeFast->SetMarkerColor(3);   /// trigger problem

--- a/fastMCKalman/tests/unitTest.sh
+++ b/fastMCKalman/tests/unitTest.sh
@@ -47,6 +47,7 @@ makePullTest(){
      testPulls("","In","&&Iteration$==0")
      testPulls("Full","In","&&Iteration$==0")
      testPulls("Full","Out","&&Iteration$==30")
+     testPulls("Full","Refit","&&Iteration$==30")
     .q
 EOF
    chmod a+x makePullTest.sh


### PR DESCRIPTION
Added content:

- Added the old `UpdateTrack` function to `AliExternalTrackParameter4D` and made it static
- Added a `fParamRefit` and `fStatusMaskRefit` vectors:
   -For the status mask added flag values relevant to the Refit: `kTrackUsedIn`, `kTrackUsedOut`, `kTrackRefitted`
- Added a `particleRefit` function to fastParticle